### PR TITLE
Break more qti telephony bones

### DIFF
--- a/src/com/android/server/telecom/CallIntentProcessor.java
+++ b/src/com/android/server/telecom/CallIntentProcessor.java
@@ -167,11 +167,6 @@ public class CallIntentProcessor {
             clientExtras.putString(TelecomManager.EXTRA_CALL_SUBJECT, callsubject);
         }
 
-        final int callDomain = intent.getIntExtra(
-                QtiCallConstants.EXTRA_CALL_DOMAIN, QtiCallConstants.DOMAIN_AUTOMATIC);
-        Log.d(CallIntentProcessor.class, "callDomain = " + callDomain);
-        clientExtras.putInt(QtiCallConstants.EXTRA_CALL_DOMAIN, callDomain);
-
         final int videoState = intent.getIntExtra( TelecomManager.EXTRA_START_CALL_WITH_VIDEO_STATE,
                 VideoProfile.STATE_AUDIO_ONLY);
         clientExtras.putInt(TelecomManager.EXTRA_START_CALL_WITH_VIDEO_STATE, videoState);
@@ -214,6 +209,15 @@ public class CallIntentProcessor {
                 }
             }
         });
+
+        try {
+            final int callDomain = intent.getIntExtra(
+                    QtiCallConstants.EXTRA_CALL_DOMAIN, QtiCallConstants.DOMAIN_AUTOMATIC);
+            Log.d(CallIntentProcessor.class, "callDomain = " + callDomain);
+            clientExtras.putInt(QtiCallConstants.EXTRA_CALL_DOMAIN, callDomain);
+        } catch (NoClassDefFoundError ex) {
+            // Do nothing
+        }
     }
 
     static void sendNewOutgoingCallIntent(Context context, Call call, CallsManager callsManager,

--- a/src/com/android/server/telecom/CallsManager.java
+++ b/src/com/android/server/telecom/CallsManager.java
@@ -547,7 +547,11 @@ public class CallsManager extends Call.ListenerBase
                 CarrierConfigManager.ACTION_CARRIER_CONFIG_CHANGED);
         intentFilter.addAction(SystemContract.ACTION_BLOCK_SUPPRESSION_STATE_CHANGED);
         context.registerReceiver(mReceiver, intentFilter);
-        QtiCarrierConfigHelper.getInstance().setup(mContext);
+        try {
+            QtiCarrierConfigHelper.getInstance().setup(mContext);
+        } catch (NoClassDefFoundError ex) {
+            // Do nothing
+        }
     }
 
     public void setIncomingCallNotifier(IncomingCallNotifier incomingCallNotifier) {
@@ -728,10 +732,14 @@ public class CallsManager extends Call.ListenerBase
             return true;
         }
 
-        final boolean isLowBattery = extras.getBoolean(QtiCallConstants.LOW_BATTERY_EXTRA_KEY,
-                false);
-        Log.d(TAG, "isIncomingVideoCallAllowed: lowbattery = " + isLowBattery);
-        return !isLowBattery;
+        try {
+            final boolean isLowBattery = extras.getBoolean(QtiCallConstants.LOW_BATTERY_EXTRA_KEY,
+                    false);
+            Log.d(TAG, "isIncomingVideoCallAllowed: lowbattery = " + isLowBattery);
+            return !isLowBattery;
+        } catch (NoClassDefFoundError ex) {
+            return true;
+        }
     }
 
     private static boolean isIncomingVideoCall(Call call) {
@@ -1286,6 +1294,22 @@ public class CallsManager extends Call.ListenerBase
         return reusedCall;
     }
 
+    private boolean isCarrierConfigEnabled(int phoneId, Context context, String config) {
+        try {
+        return QtiImsExtUtils.isCarrierConfigEnabled(phoneId, context, config);
+        } catch (NoClassDefFoundError ex) {
+            return false;
+        }
+    }
+
+    private boolean isRttSupportedOnVtCalls(int phoneId, Context context) {
+        try {
+            return QtiImsExtUtils.isRttSupportedOnVtCalls(phoneId, context);
+        } catch (NoClassDefFoundError ex) {
+            return false;
+        }
+    }
+
     /**
      * Kicks off the first steps to creating an outgoing call.
      *
@@ -1610,7 +1634,7 @@ public class CallsManager extends Call.ListenerBase
                             mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(
                             callToUse.getTargetPhoneAccount()));
                     if (!isVoicemail && (!VideoProfile.isVideo(callToUse.getVideoState())
-                            || QtiImsExtUtils.isRttSupportedOnVtCalls(
+                            || isRttSupportedOnVtCalls(
                             phoneId, mContext))
                             && (isRttSettingOn
                             || (extras != null
@@ -3857,7 +3881,7 @@ public class CallsManager extends Call.ListenerBase
         PhoneAccountHandle accountHandle = call.getTargetPhoneAccount();
         int phoneId = SubscriptionManager.getPhoneId(
                 mPhoneAccountRegistrar.getSubscriptionIdForPhoneAccount(accountHandle));
-        return QtiImsExtUtils.isCarrierConfigEnabled(phoneId, mContext,
+        return isCarrierConfigEnabled(phoneId, mContext,
                 "config_enable_video_crbt") && getDialingCall() != null
             && !VideoProfile.isTransmissionEnabled(videoState)
             && VideoProfile.isReceptionEnabled(videoState);


### PR DESCRIPTION
On older phone like Redmi Note 3 Pro, will bootloop because it didn't have the needed Class

java.lang.ClassNotFoundException: org.codeaurora.ims.utils.QtiCarrierConfigHelper

So by add ExceptionHandling, it can booting properly

Signed-off-by: Pranav Vashi <neobuddy89@gmail.com>